### PR TITLE
fix: segmentation crash for kconf cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dist/
 
 # VS Code
 .vscode/*
+
+/kconf

--- a/pkg/tui/context_list.go
+++ b/pkg/tui/context_list.go
@@ -66,7 +66,12 @@ func ShowContextList(title string, picked string, conf *kconf.KubeConfig) (strin
 	for _, ctx := range conf.Contexts {
 		itm := contextItem{}
 		itm.Name = ctx.Name
-		itm.ClusterURL = conf.GetCluster(ctx.Context.Cluster).Cluster.Server
+
+		cluster := conf.GetCluster(ctx.Context.Cluster)
+		if cluster != nil {
+			itm.ClusterURL = cluster.Cluster.Server
+		}
+
 		itm.Namespace = ctx.Context.Namespace
 		items = append(items, itm)
 	}


### PR DESCRIPTION
When you do kconf cc for a kubeconfig file, where is context reffering to non-existing cluster, the app will crash. That's because I always expected the existing cluster - not broken configuration.

Anyway even broken configuration should somehow work. I've fixed it by checking if cluster exist. If not, then the empty URL is used in list.

see #18 