### PR TITLE
feat(#12): implementing --as for import/export

### DIFF
--- a/cmd/kconf/export/export.go
+++ b/cmd/kconf/export/export.go
@@ -16,6 +16,10 @@ var Cmd = &cli.Command{
 			Name:  "kubeconfig",
 			Usage: "path to the kubeconfig file from where context is exported",
 		},
+		&cli.StringFlag{
+			Name:  "as",
+			Usage: "import context, user and cluster AS. this option rename the imported context (only if it's one)",
+		},
 	},
 
 	// main entry point for 'export'
@@ -27,7 +31,11 @@ var Cmd = &cli.Command{
 			return err
 		}
 
-		exportedCfg, err := kc.Export(contextName)
+		opts := kconf.ExportOptions{
+			As: cCtx.String("as"),
+		}
+
+		exportedCfg, err := kc.Export(contextName, &opts)
 		if err != nil {
 			return err
 		}

--- a/cmd/kconf/imprt/imprt.go
+++ b/cmd/kconf/imprt/imprt.go
@@ -16,6 +16,10 @@ var Cmd = &cli.Command{
 			Name:  "kubeconfig",
 			Usage: "path to the dest. kubeconfig where context is imported",
 		},
+		&cli.StringFlag{
+			Name:  "as",
+			Usage: "import context, user and cluster AS. this option rename the imported context (only if it's one)",
+		},
 		&cli.BoolFlag{
 			Name:  "base64",
 			Usage: "if your input is base64 decoded kubeconfig",
@@ -51,7 +55,8 @@ var Cmd = &cli.Command{
 			return err
 		}
 
-		kc.Import(sourceCfg)
+		opts := kconf.ImportOptions{As: cCtx.String("as")}
+		kc.Import(sourceCfg, &opts)
 
 		err = kc.Save(path)
 		if err != nil {

--- a/pkg/kconf/kubeconfig_test.go
+++ b/pkg/kconf/kubeconfig_test.go
@@ -58,7 +58,7 @@ func Test_Import(t *testing.T) {
 	cfg1, _, _ := Open(Abs("import-1.yaml"))
 	cfg2, _, _ := Open(Abs("import-2.yaml"))
 
-	cfg1.Import(cfg2)
+	cfg1.Import(cfg2, &ImportOptions{})
 	cfg1.Save(Abs("import-result.yaml"))
 
 	// validate users

--- a/pkg/kconf/options.go
+++ b/pkg/kconf/options.go
@@ -5,6 +5,14 @@ type CtxmodOptions struct {
 	User    string
 }
 
+type ImportOptions struct {
+	As string
+}
+
+type ExportOptions struct {
+	As string
+}
+
 type ClustermodOptions struct {
 	ServerURL string
 }


### PR DESCRIPTION
Sometimes it's handy to rename imported/exported context in one shot